### PR TITLE
Fix tvOS support

### DIFF
--- a/AdvancedFramework.xcodeproj/project.pbxproj
+++ b/AdvancedFramework.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		2B3A82482A5D821E0093CDC4 /* GoogleCastSDK-ios-no-bluetooth in Frameworks */ = {isa = PBXBuildFile; productRef = 2B3A82472A5D821E0093CDC4 /* GoogleCastSDK-ios-no-bluetooth */; };
+		2B3A82482A5D821E0093CDC4 /* GoogleCastSDK-ios-no-bluetooth in Frameworks */ = {isa = PBXBuildFile; platformFilter = ios; productRef = 2B3A82472A5D821E0093CDC4 /* GoogleCastSDK-ios-no-bluetooth */; };
 		37B700E12A30A40700B40A55 /* AdvancedFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 37B700E02A30A40700B40A55 /* AdvancedFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		37B700E82A30A43E00B40A55 /* PlayerWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B700E72A30A43E00B40A55 /* PlayerWrapper.swift */; };
 		37B700EB2A30A48A00B40A55 /* BitmovinPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = 37B700EA2A30A48A00B40A55 /* BitmovinPlayer */; };
@@ -338,7 +338,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 942275CR6V;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";

--- a/AdvancedFramework/PlayerWrapper.swift
+++ b/AdvancedFramework/PlayerWrapper.swift
@@ -9,13 +9,16 @@
 import BitmovinPlayer
 import BitmovinCollector
 import CoreCollector
+#if os(iOS)
 import GoogleCast
+#endif
 
 // This sample showcases how the BitmovinPlayer could be used from within another Framework which wraps the Player.
 public class PlayerWrapper {
     private let player: Player
     private let collector: BitmovinPlayerCollector
     
+#if os(iOS)
     private var bitmovinCastManager: BitmovinCastManager
     // Bitmovin cast manger options
     private let bitmovinCastManagerOptions = BitmovinCastManagerOptions()
@@ -23,6 +26,7 @@ public class PlayerWrapper {
     private static var namespace = "urn:x-cast:com.mediakind.cast.media"
     // ID to communicate with receiver
     private static var applicationId = "5A468DEE"
+#endif
     
 
     public init() {
@@ -33,7 +37,7 @@ public class PlayerWrapper {
 
         self.player = PlayerFactory.create(playerConfig: playerConfig)
         self.collector = BitmovinPlayerCollector(config: analyticsConfig)
-        
+#if os(iOS)
         bitmovinCastManagerOptions.deviceDiscoveryMode = .castButtonInteraction
         bitmovinCastManagerOptions.applicationId = "5A468DEE"
         bitmovinCastManagerOptions.messageNamespace = PlayerWrapper.namespace
@@ -41,6 +45,7 @@ public class PlayerWrapper {
         BitmovinCastManager.initializeCasting(options: bitmovinCastManagerOptions)
         bitmovinCastManager = BitmovinCastManager.sharedInstance()
         let currentMediaStatus = bitmovinCastManager.currentMediaStatus
+#endif
     }
 
     func setup() {


### PR DESCRIPTION
### Description
Since the current setup of the framework is a multiplatform framework, it is needed to also respect that in the source for proper tvOS support.

### Changes
- Wrapped all casting-related API inside an `#if os(iOS)` check.
- Only link against the `GoogleCastSDK` for iOS